### PR TITLE
Add support for replacements containing html tags

### DIFF
--- a/addon/dom-manipulator.js
+++ b/addon/dom-manipulator.js
@@ -1,11 +1,14 @@
-const treeWalker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+const treeWalker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT); // filter to only text nodes
 
 chrome.storage.local.get(null, (res) => {
+	// retrieve settings
 	for (let setting in res) {
 		emojiReplacer.set(setting, res[setting]);
 	}
+
+	// perform replacement on each text node in document
 	while (treeWalker.nextNode()) {
-		const original = treeWalker.currentNode.nodeValue;
-		treeWalker.currentNode.nodeValue = original.replace(emojiReplacer.pattern, emojiReplacer.replaceMatch);
+		const originalNode = treeWalker.currentNode;
+		emojiReplacer.translateTextNode(originalNode);
 	}
 });

--- a/addon/emoji-replacer.js
+++ b/addon/emoji-replacer.js
@@ -48,35 +48,31 @@ const emojiReplacer = (function(){
 			return match;
 		}
 		if (settings.showEmoji) {
-                        if (settings.nameInMouseover) {
-                            translation += "<span title=\"";
-                            translation += nameWithDelimiter(name);
-                            translation += "\">";
-                            translation += match;
-                            translation += "</span>";
-                        } else {
-                            translation += match;
-                        }
+			if (settings.nameInMouseover) {
+				translation = `<span title="${nameWithDelimiter(name)}">${match}</span>`
+			} else {
+				translation = match;
+			}
 		}
 		if (settings.nameAfterEmoji) {
-                    translation += nameWithDelimiter(name);
-                }
+			translation += nameWithDelimiter(name);
+		}
 		return translation;
 	}
 	
 	function nameWithDelimiter(namegoeshere) {
-                let result = '';
-                if (settings.wrapper !== 'nothing') {
-                        if (settings.wrapper === 'custom') {
-                                result += [settings.wrapStart, settings.wrapEnd].join(namegoeshere);
-                        } else {
-                                result += wrappers[settings.wrapper].join(namegoeshere);
-                        }
-                } else {
-                        result += namegoeshere;
-                }
-                return result;
-        }
+		let result = '';
+		if (settings.wrapper !== 'nothing') {
+			if (settings.wrapper === 'custom') {
+				result += [settings.wrapStart, settings.wrapEnd].join(namegoeshere);
+			} else {
+				result += wrappers[settings.wrapper].join(namegoeshere);
+			}
+		} else {
+			result += namegoeshere;
+		}
+		return result;
+	}
 
 	// returns list of translated emojis and list of surrounding texts
 	// if no emojis are found, returns false

--- a/addon/settings.js
+++ b/addon/settings.js
@@ -27,8 +27,10 @@ function restoreSettings() {
 			}
 		} else {
 			for (let setting in res) {
-				document.forms[0].elements[setting].value = res[setting];
-				emojiReplacer.set(setting, res[setting]);
+				if (document.forms[0].elements[setting]) {
+					document.forms[0].elements[setting].value = res[setting];
+					emojiReplacer.set(setting, res[setting]);
+				}
 			}
 		}
 		displayPreview();
@@ -36,10 +38,10 @@ function restoreSettings() {
 }
 
 function displayPreview() {
-	const original = document.querySelector('#original samp').textContent;
 	const translatedNode = document.querySelector('#translated samp');
+	translatedNode.textContent = document.querySelector('#original samp').textContent;
 
-	translatedNode.textContent = original.replace(emojiReplacer.pattern, emojiReplacer.replaceMatch);
+	emojiReplacer.translateTextNode(translatedNode.childNodes[0]);
 }
 
 document.addEventListener("DOMContentLoaded", restoreSettings);


### PR DESCRIPTION
This should fix the tooltips feature.

I am planning on releasing a new version with this feature to the Chrome and Mozilla add-ons repos, if that's okay with you.